### PR TITLE
fix inconsistent parameters and unsupported slicing

### DIFF
--- a/data_preparation/generate_fft_images.py
+++ b/data_preparation/generate_fft_images.py
@@ -43,7 +43,7 @@ def main():
     if platform.system() == 'Linux':
         parser.add_argument('-l','--save_data_dir', default='/slow1/out_datasets/tuh/seizure_type_classification/',
                             help='path to output prediction')
-        parser.add_argument('-b','--base_save_data_dir', default='/fast1/out_datasets/tuh/seizure_type_classification/',
+        parser.add_argument('-b','--preprocess_data_dir', default='/fast1/out_datasets/tuh/seizure_type_classification/',
                             help='path to output prediction')
     elif platform.system() == 'Darwin':
         parser.add_argument('-l','--save_data_dir', default='/Users/jbtang/datasets/TUH/eeg_seizure/',

--- a/data_preparation/generate_fft_time_freq_coeffs.py
+++ b/data_preparation/generate_fft_time_freq_coeffs.py
@@ -44,7 +44,7 @@ def main():
     if platform.system() == 'Linux':
         parser.add_argument('-l','--save_data_dir', default='/slow1/out_datasets/tuh/seizure_type_classification/',
                             help='path from resampled seizure data')
-        parser.add_argument('-b','--base_save_data_dir', default='/fast1/out_datasets/tuh/seizure_type_classification/',
+        parser.add_argument('-b','--preprocess_data_dir', default='/fast1/out_datasets/tuh/seizure_type_classification/',
                             help='path to processed data')
     elif platform.system() == 'Darwin':
         parser.add_argument('-l','--save_data_dir', default='/Users/jbtang/datasets/TUH/eeg_seizure/',

--- a/preprocess/preprocessing_library.py
+++ b/preprocess/preprocessing_library.py
@@ -23,9 +23,7 @@ class Slice:
         return "slice%d-%d" % (self.start, self.stop)
 
     def apply(self, data):
-        s = [slice(None),] * data.ndim
-        s[-1] = slice(self.start, self.stop)
-        return data[s]
+        return data[..., self.start:self.stop]
 
 class Magnitude:
     """


### PR DESCRIPTION
1.  In both *data_preparation/generate_fft_images.py* and *data_preparation/generate_time_freq_coeffs.py*, the macOS parameter was renamed to `preprocess_data_dir` from `base_save_data_dir`, but this change was not applied to the Linux parameter. This PR fixes the inconsistency by updating the Linux parameter.
2.  The use of a list of slices in `preprocess/preprocessing_library.py` is unsupported by (perhaps the current version of) NumPy. This PR updates it to simplify the logic to use a [more standard ellipsis](https://numpy.org/doc/stable/user/basics.indexing.html#dimensional-indexing-tools) instead.